### PR TITLE
swig - cpp BUGFIX include paths to libyang headers

### DIFF
--- a/swig/cpp/src/Internal.cpp
+++ b/swig/cpp/src/Internal.cpp
@@ -26,9 +26,9 @@
 #include "Tree_Data.hpp"
 
 extern "C" {
-#include <libyang/libyang.h>
-#include <libyang/tree_data.h>
-#include <libyang/tree_schema.h>
+#include "../../../src/libyang.h"
+#include "../../../src/tree_data.h"
+#include "../../../src/tree_schema.h"
 }
 
 using namespace std;

--- a/swig/cpp/src/Internal.hpp
+++ b/swig/cpp/src/Internal.hpp
@@ -144,7 +144,7 @@
 #include <memory>
 
 extern "C" {
-#include <libyang/libyang.h>
+#include "../../../src/libyang.h"
 }
 
 #define typeof(x) __typeof__(x)

--- a/swig/cpp/src/Libyang.cpp
+++ b/swig/cpp/src/Libyang.cpp
@@ -31,9 +31,9 @@
 #include "Tree_Schema.hpp"
 
 extern "C" {
-#include <libyang/libyang.h>
-#include <libyang/tree_data.h>
-#include <libyang/tree_schema.h>
+#include "../../../src/libyang.h"
+#include "../../../src/tree_data.h"
+#include "../../../src/tree_schema.h"
 }
 
 using namespace std;

--- a/swig/cpp/src/Libyang.hpp
+++ b/swig/cpp/src/Libyang.hpp
@@ -30,7 +30,7 @@
 #include "Internal.hpp"
 
 extern "C" {
-#include <libyang/libyang.h>
+#include "../../../src/libyang.h"
 }
 
 using namespace std;

--- a/swig/cpp/src/Tree_Data.cpp
+++ b/swig/cpp/src/Tree_Data.cpp
@@ -29,9 +29,9 @@
 #include "Tree_Schema.hpp"
 
 extern "C" {
-#include <libyang/libyang.h>
-#include <libyang/tree_data.h>
-#include <libyang/tree_schema.h>
+#include "../../../src/libyang.h"
+#include "../../../src/tree_data.h"
+#include "../../../src/tree_schema.h"
 }
 
 using namespace std;

--- a/swig/cpp/src/Tree_Data.hpp
+++ b/swig/cpp/src/Tree_Data.hpp
@@ -30,8 +30,8 @@
 #include "Tree_Schema.hpp"
 
 extern "C" {
-#include <libyang/libyang.h>
-#include <libyang/tree_data.h>
+#include "../../../src/libyang.h"
+#include "../../../src/tree_data.h"
 }
 
 using namespace std;

--- a/swig/cpp/src/Tree_Schema.cpp
+++ b/swig/cpp/src/Tree_Schema.cpp
@@ -28,8 +28,8 @@
 #include "Tree_Schema.hpp"
 
 extern "C" {
-#include <libyang/libyang.h>
-#include <libyang/tree_schema.h>
+#include "../../../src/libyang.h"
+#include "../../../src/tree_schema.h"
 }
 
 using namespace std;

--- a/swig/cpp/src/Tree_Schema.hpp
+++ b/swig/cpp/src/Tree_Schema.hpp
@@ -30,8 +30,8 @@
 #include "Libyang.hpp"
 
 extern "C" {
-#include <libyang/libyang.h>
-#include <libyang/tree_schema.h>
+#include "../../../src/libyang.h"
+#include "../../../src/tree_schema.h"
 }
 
 using namespace std;

--- a/swig/cpp/src/Xml.cpp
+++ b/swig/cpp/src/Xml.cpp
@@ -28,8 +28,8 @@
 #include "Xml.hpp"
 
 extern "C" {
-#include <libyang/libyang.h>
-#include <libyang/xml.h>
+#include "../../../src/libyang.h"
+#include "../../../src/xml.h"
 }
 
 using namespace std;

--- a/swig/cpp/src/Xml.hpp
+++ b/swig/cpp/src/Xml.hpp
@@ -30,8 +30,8 @@
 #include "Internal.hpp"
 
 extern "C" {
-#include <libyang/libyang.h>
-#include <libyang/xml.h>
+#include "../../../src/libyang.h"
+#include "../../../src/xml.h"
 }
 
 using namespace std;


### PR DESCRIPTION
system paths cannot be used since libyang is not yet installed during
the first build. Therefore, the libyang headers must be included from
the relative source paths.