### PR TITLE
Python BUGFIX reflect API changes in examples

### DIFF
--- a/swig/python/examples/process_tree.py
+++ b/swig/python/examples/process_tree.py
@@ -23,12 +23,12 @@ else:
     module = ctx.load_module("turing-machine", None)
 
 try:
-    node = ctx.parse_path("/etc/sysrepo/data/turing-machine.startup", ly.LYD_XML, ly.LYD_OPT_CONFIG)
+    node = ctx.parse_data_path("/etc/sysrepo/data/turing-machine.startup", ly.LYD_XML, ly.LYD_OPT_CONFIG)
 except Exception as e:
     print(e)
 
 if node is None:
-    print("parse_path did not return any nodes")
+    print("parse_data_path did not return any nodes")
 else:
     print("tree_dfs\n")
     data_list = node.tree_dfs()

--- a/swig/python/examples/xpath.py
+++ b/swig/python/examples/xpath.py
@@ -17,7 +17,7 @@ if module is None:
     sys.exit()
 
 try:
-    node = ctx.parse_path("/etc/sysrepo/data/turing-machine.startup", ly.LYD_XML, ly.LYD_OPT_CONFIG)
+    node = ctx.parse_data_path("/etc/sysrepo/data/turing-machine.startup", ly.LYD_XML, ly.LYD_OPT_CONFIG)
 except Exception as e:
     print(e)
     sys.exit()


### PR DESCRIPTION
Context's 'parse_path()' is now 'parse_data_path()'